### PR TITLE
Add geomap dashboard and hivewatch map runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,61 @@ fedviz.finish()
 
 `fedviz` uses a pluggable emitter system. Construct emitter instances and pass them to `init()`. You can use multiple emitters simultaneously.
 
+**Local map / deferred map metadata:**
+
+```python
+from fedviz.emitters import SSEEmitter
+
+fedviz.init(
+    algorithm = "FedAvg",
+    emitters  = [SSEEmitter(port=7070, serve_map=False)],
+)
+```
+
+`SSEEmitter` now persists both:
+- `runs/<run_id>.jsonl` for full event history / replay
+- `runs/<run_id>.map.json` for map-ready metadata that can be reloaded later without replaying the raw log
+
+Serve the dashboard separately:
+
+```bash
+hivewatch map run --runs-dir runs --port 7070
+```
+
+Common `hivewatch map run` arguments:
+
+```bash
+hivewatch map run \
+  --host 0.0.0.0 \
+  --port 7070 \
+  --runs-dir runs \
+  --run-id run-abc123 \
+  --map-path examples/fedviz_map.html \
+  --poll-interval 1.0
+```
+
+- `--host`: host/interface to bind the dashboard server to
+- `--port`: port for the dashboard HTTP server
+- `--runs-dir`: directory containing `*.jsonl` and `*.map.json` run artifacts
+- `--run-id`: load one specific run by run id or filename instead of watching for the latest live run
+- `--map-path`: serve a custom HTML map file instead of the default bundled viewer
+- `--poll-interval`: how often, in seconds, to poll `--runs-dir` for new runs/updates
+
+Examples:
+
+```bash
+# Watch a runs directory for live updates
+hivewatch map run --runs-dir runs --port 7070
+
+# Open a single saved run in static mode
+hivewatch map run --runs-dir runs --run-id run-abc123
+
+# Serve a custom viewer HTML file
+hivewatch map run --runs-dir runs --map-path examples/fedviz_map.html
+```
+
+The bundled `examples/fedviz_map.html` viewer loads map metadata first and falls back to the JSONL-derived event history for older runs. This keeps the local dashboard flow and a future “save now, render later” flow compatible with the same viewer.
+
 **Weights & Biases:**
 
 ```python
@@ -223,6 +278,11 @@ fedviz
 ```
 
 fedviz never touches the transport layer or the framework. The user bridges their framework to fedviz the same way they would bridge it to W&B.
+
+For map visualization, the intended storage contract is now a standalone metadata artifact in addition to the raw event log. That supports:
+- local CLI runs that immediately launch or serve a map
+- local or remote servers that persist metadata for later display
+- future integrations such as Appflx storing metadata in object storage and reloading it in a separate web tier
 
 ## Project structure
 

--- a/examples/appfl/README.md
+++ b/examples/appfl/README.md
@@ -1,6 +1,6 @@
 # `APPFL` + `fedviz` Example
 
-This example runs a 2-client federated learning job using [APPFL](https://github.com/APPFL/APPFL) with FedAvg over gRPC, while logging training metrics to W&B and MLflow via **fedviz**.
+This example runs a 2-client federated learning job using [APPFL](https://github.com/APPFL/APPFL) with FedAvg over gRPC, while logging training metrics and map metadata via **fedviz**.
 
 ## What the example does
 
@@ -13,7 +13,7 @@ Make sure you have `appfl` and `fedviz` installed, along with the required depen
 
 ## Running the example
 
-The server must be started before the clients. Open **three terminals**, all from the `examples/appfl/` directory.
+The server must be started before the clients. Open **four terminals**, all from the `examples/appfl/` directory.
 
 **Terminal 1 — server**
 ```bash
@@ -22,12 +22,17 @@ python run_server.py
 python run_server.py --config ./resources/configs/server_fedavg.yaml
 ```
 
-**Terminal 2 — client 1**
+**Terminal 2 — map**
+```bash
+hivewatch map run --runs-dir runs --port 7070
+```
+
+**Terminal 3 — client 1**
 ```bash
 python run_client.py --config ./resources/configs/client_1.yaml
 ```
 
-**Terminal 3 — client 2**
+**Terminal 4 — client 2**
 ```bash
 python run_client.py --config ./resources/configs/client_2.yaml
 ```
@@ -36,7 +41,7 @@ Training finishes automatically after 10 global rounds. Results are written to `
 
 ## Monitoring backends
 
-The server initializes two emitters in `run_server.py`:
+The server initializes three emitters in `run_server.py`:
 
 ```python
 fedviz.init(
@@ -44,6 +49,7 @@ fedviz.init(
     config    = dict(server_agent_config.server_configs),
     emitters  = [
         WandbEmitter(project="my-fl-project-wandb"),
+        SSEEmitter(port=7070, serve_map=False),
         MLflowEmitter(experiment="my-fl-project-mlflow"),
     ],
 )
@@ -51,5 +57,8 @@ fedviz.init(
 
 - **W&B**: Metrics appear in the `my-fl-project-wandb` project. Requires `WANDB_API_KEY` to be set, or run `wandb login` first.
 - **MLflow**: Runs are recorded in the `my-fl-project-mlflow` experiment. The tracking URI defaults to `./mlruns`; override with `MLFLOW_TRACKING_URI`.
+- **Map metadata + local viewer**: `SSEEmitter` writes raw events to `runs/<run_id>.jsonl` and map-ready metadata to `runs/<run_id>.map.json`. Serve the dashboard separately with `hivewatch map run --runs-dir runs --port 7070`.
 
 To use only one backend, remove the unwanted emitter from the list.
+
+For an Appflx-style deployment, the map metadata file is the preferred interchange format: save it locally during training, move it to shared storage such as S3, and have a separate web tier reload it later with the same viewer.

--- a/examples/appfl/map_utils.py
+++ b/examples/appfl/map_utils.py
@@ -1,0 +1,54 @@
+"""Utility functions for fedviz geo-location and client IP resolution."""
+
+import requests
+
+
+def is_local(peer: str) -> bool:
+    """Check if peer is local/non-routable."""
+    return not peer or any(x in peer for x in ("127.0.0.1", "localhost", "[::1]"))
+
+
+def parse_ip(raw_peer: str) -> str:
+    """Extract plain IP from gRPC peer string like 'ipv4:54.183.207.31:50546'."""
+    if not raw_peer:
+        return ""
+    parts = raw_peer.replace("ipv4:", "").replace("ipv6:", "").split(":")
+    return parts[0] if parts else ""
+
+
+def get_location(ip: str) -> dict:
+    """Resolve IP to location using ipinfo.io (free, no API key needed)."""
+    try:
+        response = requests.get(f"https://ipinfo.io/{ip}/json", timeout=5)
+        if response.status_code == 200:
+            data = response.json()
+            location = {
+                "ip": data.get("ip", ip),
+                "city": data.get("city", "Unknown"),
+                "region": data.get("region", "Unknown"),
+                "country": data.get("country", "Unknown"),
+                "org": data.get("org", "Unknown"),
+                "lat": None,
+                "lng": None,
+            }
+            loc = data.get("loc", "")
+            if loc:
+                lat, lng = loc.split(",")
+                location["lat"] = float(lat)
+                location["lng"] = float(lng)
+            return location
+    except Exception as e:
+        print(f"[fedviz/geo] Failed to resolve IP {ip}: {e}")
+    return {}
+
+
+def extract_client_id(obj):
+    """Extract client_id from request object."""
+    try:
+        return obj.header.client_id
+    except (AttributeError, TypeError):
+        for attr in ("client_id", "id"):
+            val = getattr(obj, attr, None)
+            if val:
+                return val
+    return None

--- a/examples/appfl/run_server.py
+++ b/examples/appfl/run_server.py
@@ -1,22 +1,27 @@
-
 import fedviz
 import argparse
+import os
 from omegaconf import OmegaConf
 from appfl.agent import ServerAgent
 from appfl.comm.grpc import GRPCServerCommunicator, serve
-from fedviz.emitters import WandbEmitter, MLflowEmitter
+from fedviz.emitters import WandbEmitter, MLflowEmitter, SSEEmitter
+from map_utils import is_local, parse_ip, get_location, extract_client_id
 
+
+# ── FedViz Server Agent ───────────────────────────────────────────────────────
 class FedVizServerAgent(ServerAgent):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._current_round = -1
         self._last_accuracy = 0.0
         self._last_loss     = 0.0
-       
+        self._peer_by_client = {}       # client_id (str) -> raw peer string
+        self._client_locs    = {}       # client_id (str) -> location dict
 
     def global_update(self, client_id, local_model, *args, **kwargs):
         round_num = kwargs.get("round", 0)
 
+        # ── Log round transition ──────────────────────────────────────────────
         if round_num != self._current_round:
             if self._current_round >= 0:
                 fedviz.log_round(
@@ -30,8 +35,35 @@ class FedVizServerAgent(ServerAgent):
         self._last_accuracy = kwargs.get("val_accuracy", 0.0)
         self._last_loss     = kwargs.get("val_loss",     0.0)
 
+        # ── Resolve client IP and location ────────────────────────────────────
+        raw_peer = self._peer_by_client.get(str(client_id), "")
+        parsed_ip = parse_ip(raw_peer)
+        geo = {}
+
+        print(f"\n[CLIENT] client_id={client_id} | round={round_num}")
+        print(f"  raw_peer  : {raw_peer!r}")
+        print(f"  parsed_ip : {parsed_ip!r}")
+
+        if parsed_ip and not is_local(parsed_ip):
+            # Resolve location only once per client
+            if str(client_id) not in self._client_locs:
+                self._client_locs[str(client_id)] = get_location(parsed_ip)
+            
+            loc = self._client_locs[str(client_id)]
+            if loc:
+                print(f"  location  : {loc.get('city')}, {loc.get('region')}, {loc.get('country')}")
+                print(f"  org       : {loc.get('org')}")
+                print(f"  lat/lng   : {loc.get('lat')}, {loc.get('lng')}")
+                geo = {k: v for k, v in loc.items() if k in ("lat", "lng", "city", "country")}
+            else:
+                print(f"  location  : Could not resolve")
+        else:
+            print(f"  location  : Local/non-routable, skipping geo resolution")
+
+        # ── Run aggregation ───────────────────────────────────────────────────
         result = super().global_update(client_id, local_model, *args, **kwargs)
 
+        # ── Log client update to fedviz ───────────────────────────────────────
         fedviz.log_client_update(
             client_id      = client_id,
             round          = round_num,
@@ -43,11 +75,51 @@ class FedVizServerAgent(ServerAgent):
             cpu_pct        = kwargs.get("cpu_pct"),
             ram_mb         = kwargs.get("ram_mb"),
             bytes_sent     = kwargs.get("bytes_sent", 0),
+            **geo,
         )
 
         return result
 
 
+# ── Patch communicator to capture peer IP per client_id ───────────────────────
+def patch_communicator_for_geo(communicator, server_agent: FedVizServerAgent):
+    """Wrap RPC methods to capture peer->client_id mapping on connection."""
+    
+    def record_peer(client_id, peer):
+        """Record peer mapping if not already present."""
+        if client_id and str(client_id) not in server_agent._peer_by_client:
+            server_agent._peer_by_client[str(client_id)] = peer
+            print(f"[fedviz/patch] Mapped client_id={client_id!r} -> peer={peer!r}")
+
+    def wrap_method(original):
+        """Wrap RPC method to capture peer and client_id."""
+        def wrapped(request_or_iter, context):
+            peer = context.peer()
+            print(f"[fedviz/patch] Incoming connection | peer={peer!r}")
+            
+            # Handle both streaming and non-streaming requests
+            if hasattr(request_or_iter, '__iter__') and hasattr(request_or_iter, '__next__'):
+                def capturing_iterator():
+                    for request in request_or_iter:
+                        record_peer(extract_client_id(request), peer)
+                        yield request
+                return original(capturing_iterator(), context)
+            else:
+                record_peer(extract_client_id(request_or_iter), peer)
+                return original(request_or_iter, context)
+        
+        return wrapped
+
+    # Patch all RPC methods that might be called by clients
+    for method_name in ["GetConfiguration", "GetGlobalModel", "UpdateGlobalModel", "InvokeCustomAction"]:
+        if hasattr(communicator, method_name):
+            setattr(communicator, method_name, wrap_method(getattr(communicator, method_name)))
+            print(f"[fedviz] Patched: {method_name}")
+    
+    print("[fedviz] All RPC methods patched for geo IP resolution")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
 argparser = argparse.ArgumentParser()
 argparser.add_argument(
     "--config",
@@ -58,18 +130,24 @@ argparser.add_argument(
 args = argparser.parse_args()
 
 server_agent_config = OmegaConf.load(args.config)
+mlflow_tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "http://localhost:5000")
+mlflow_experiment   = os.environ.get("MLFLOW_EXPERIMENT", "my-fl-project-mlflow")
+
+print(f"[fedviz] MLflow tracking URI : {mlflow_tracking_uri}")
+print(f"[fedviz] MLflow experiment   : {mlflow_experiment}")
 
 fedviz.init(
     algorithm = "FedAvg",
-    config    = dict(server_agent_config.server_configs),
+    config    = OmegaConf.to_container(server_agent_config.server_configs, resolve=True),
     emitters  = [
         WandbEmitter(project="my-fl-project-wandb"),
+        SSEEmitter(port=7070, serve_map=True),
         MLflowEmitter(
-            tracking_uri="http://localhost:5000",
-            experiment="my-fl-project-mlflow", 
-            mlflow_system_metrics=True, 
-            run_name="fedavg-run-1",
-            system_metrics_sampling_interval=5
+            tracking_uri                     = mlflow_tracking_uri,
+            experiment                       = mlflow_experiment,
+            mlflow_system_metrics            = True,
+            run_name                         = "fedavg-run-1",
+            system_metrics_sampling_interval = 5,
         ),
     ],
 )
@@ -81,16 +159,33 @@ communicator = GRPCServerCommunicator(
     logger=server_agent.logger,
     **server_agent_config.server_configs.comm_configs.grpc_configs,
 )
+patch_communicator_for_geo(communicator, server_agent)
 
 try:
     serve(communicator, **server_agent_config.server_configs.comm_configs.grpc_configs)
 finally:
-    # Log the last round before finishing
+    # ── Log final round ───────────────────────────────────────────────────────
     if server_agent._current_round >= 0:
         fedviz.log_round(
             round           = server_agent._current_round,
             global_accuracy = server_agent._last_accuracy,
             global_loss     = server_agent._last_loss,
         )
-    fedviz.finish()
 
+    # ── Print client IP and location summary ──────────────────────────────────
+    print("\n" + "="*60)
+    print("TRAINING COMPLETE — CLIENT SUMMARY")
+    print("="*60)
+    for client_id, raw_peer in server_agent._peer_by_client.items():
+        parsed_ip = parse_ip(raw_peer)
+        loc = server_agent._client_locs.get(client_id, {})
+        print(f"\n  Client   : {client_id}")
+        print(f"  IP       : {parsed_ip}")
+        print(f"  City     : {loc.get('city', 'Unknown')}")
+        print(f"  Region   : {loc.get('region', 'Unknown')}")
+        print(f"  Country  : {loc.get('country', 'Unknown')}")
+        print(f"  Org      : {loc.get('org', 'Unknown')}")
+        print(f"  Lat/Lng  : {loc.get('lat')}, {loc.get('lng')}")
+    print("="*60 + "\n")
+
+    fedviz.finish()

--- a/examples/fedviz_map.html
+++ b/examples/fedviz_map.html
@@ -1,0 +1,1012 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>FedViz — Client Map</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.css"/>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Syne:wght@600;700;800&display=swap" rel="stylesheet">
+<style>
+  /* ── Themes ── */
+  [data-theme="light"] {
+    --bg:      #f4f6f9;
+    --surface: #ffffff;
+    --border:  #e2e8f0;
+    --text:    #1a202c;
+    --muted:   #718096;
+    --tile-filter: none;
+  }
+  [data-theme="dark"] {
+    --bg:      #0a0c10;
+    --surface: #0e1318;
+    --border:  #1e2a38;
+    --text:    #c8d4e0;
+    --muted:   #4a5a6a;
+    --tile-filter: brightness(0.45) saturate(0.4) hue-rotate(180deg);
+  }
+  :root {
+    --accent:  #3b82f6;
+    --green:   #10b981;
+    --orange:  #f59e0b;
+    --red:     #ef4444;
+  }
+
+  * { margin:0; padding:0; box-sizing:border-box; }
+  body { background:var(--bg); color:var(--text); font-family:'JetBrains Mono',monospace; height:100vh; display:flex; flex-direction:column; overflow:hidden; transition:background 0.2s, color 0.2s; }
+
+  /* ── Header ── */
+  header { display:flex; align-items:center; justify-content:space-between; padding:10px 20px; background:var(--surface); border-bottom:1px solid var(--border); z-index:1000; flex-shrink:0; box-shadow:0 1px 4px rgba(0,0,0,0.06); }
+  .logo { display:flex; align-items:center; gap:10px; }
+  .logo-mark { width:30px; height:30px; background:var(--accent); border-radius:6px; display:flex; align-items:center; justify-content:center; font-family:'Syne',sans-serif; font-weight:800; font-size:13px; color:white; }
+  .logo-text { font-family:'Syne',sans-serif; font-size:17px; font-weight:700; color:var(--text); }
+  .logo-sub  { font-size:9px; color:var(--muted); letter-spacing:1px; text-transform:uppercase; }
+  .header-stats { display:flex; gap:28px; }
+  .stat { text-align:center; }
+  .stat-val   { font-size:18px; font-weight:600; color:var(--text); line-height:1; }
+  .stat-label { font-size:9px; color:var(--muted); letter-spacing:1px; text-transform:uppercase; margin-top:3px; }
+  .header-right { display:flex; align-items:center; gap:10px; }
+  .status-pill { display:flex; align-items:center; gap:7px; padding:5px 12px; border-radius:20px; border:1px solid var(--border); font-size:11px; color:var(--muted); background:var(--bg); }
+  .status-dot  { width:7px; height:7px; border-radius:50%; background:var(--muted); transition:background 0.3s; }
+  .status-dot.live { background:var(--green); box-shadow:0 0 8px var(--green); animation:pulse 2s infinite; }
+  @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
+  .theme-btn { background:var(--bg); border:1px solid var(--border); border-radius:8px; padding:5px 10px; font-size:14px; cursor:pointer; color:var(--muted); transition:all 0.15s; }
+  .theme-btn:hover { border-color:var(--accent); color:var(--accent); }
+
+  /* ── Main layout ── */
+  .main { display:flex; flex:1; overflow:hidden; min-height:0; }
+
+  /* ── Runs panel ── */
+  .runs-panel { width:190px; background:var(--surface); border-right:1px solid var(--border); display:flex; flex-direction:column; overflow:hidden; flex-shrink:0; }
+  .runs-panel-header { padding:10px 12px; border-bottom:1px solid var(--border); font-size:9px; letter-spacing:1.5px; text-transform:uppercase; color:var(--muted); display:flex; justify-content:space-between; align-items:center; }
+  .refresh-btn { background:none; border:none; cursor:pointer; color:var(--muted); font-size:13px; padding:2px 4px; border-radius:4px; transition:color 0.15s; }
+  .refresh-btn:hover { color:var(--accent); }
+  .runs-list { flex:1; overflow-y:auto; padding:6px; }
+  .runs-list::-webkit-scrollbar { width:4px; }
+  .runs-list::-webkit-scrollbar-thumb { background:var(--border); border-radius:2px; }
+  .run-item { padding:8px 10px; border-radius:6px; border:1px solid transparent; margin-bottom:4px; cursor:pointer; transition:all 0.15s; }
+  .run-item:hover { background:var(--bg); border-color:var(--border); }
+  .run-item.active { background:rgba(59,130,246,0.08); border-color:var(--accent); }
+  .run-item.live-run { border-left:3px solid var(--green); }
+  .run-id-text { font-size:11px; font-weight:600; color:var(--text); margin-bottom:3px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .run-meta { font-size:9px; color:var(--muted); line-height:1.5; }
+  .run-badge { display:inline-block; font-size:8px; padding:1px 5px; border-radius:3px; font-weight:600; margin-left:4px; vertical-align:middle; }
+  .run-badge.live { background:rgba(16,185,129,0.15); color:var(--green); }
+  .run-badge.done { background:rgba(113,128,150,0.12); color:var(--muted); }
+
+  /* ── Sidebar ── */
+  .sidebar { width:250px; background:var(--surface); border-right:1px solid var(--border); display:flex; flex-direction:column; overflow:hidden; flex-shrink:0; }
+  .sidebar-section { padding:12px 14px; border-bottom:1px solid var(--border); }
+  .section-title { font-size:9px; letter-spacing:1.5px; text-transform:uppercase; color:var(--muted); margin-bottom:10px; }
+  .round-info { display:grid; grid-template-columns:1fr 1fr; gap:6px; }
+  .round-stat { background:var(--bg); border:1px solid var(--border); border-radius:6px; padding:8px 10px; }
+  .round-stat .val { font-size:16px; font-weight:600; color:var(--text); line-height:1; }
+  .round-stat .lbl { font-size:9px; color:var(--muted); margin-top:3px; }
+  .client-list { flex:1; overflow-y:auto; padding:8px; }
+  .client-list::-webkit-scrollbar { width:4px; }
+  .client-list::-webkit-scrollbar-thumb { background:var(--border); border-radius:2px; }
+  .client-card { padding:10px 12px; border-radius:8px; border:1px solid var(--border); margin-bottom:6px; cursor:pointer; transition:all 0.2s; background:var(--surface); }
+  .client-card:hover { border-color:var(--accent); box-shadow:0 2px 8px rgba(59,130,246,0.1); }
+  .client-header { display:flex; align-items:center; justify-content:space-between; margin-bottom:5px; }
+  .client-id { font-size:11px; font-weight:600; color:var(--text); }
+  .client-badge { width:7px; height:7px; border-radius:50%; background:var(--green); flex-shrink:0; }
+  .client-badge.idle    { background:var(--orange); }
+  .client-badge.dropped { background:var(--red); }
+  .client-location { font-size:10px; color:var(--muted); margin-bottom:5px; }
+  .client-metrics { display:grid; grid-template-columns:1fr 1fr; gap:4px; }
+  .metric-chip { background:var(--bg); border:1px solid var(--border); border-radius:4px; padding:3px 6px; font-size:10px; }
+  .metric-chip .val { color:var(--text); font-weight:500; }
+  .metric-chip .lbl { color:var(--muted); font-size:9px; }
+
+  /* ── Map ── */
+  .map-area { flex:1; position:relative; display:flex; flex-direction:column; min-height:0; }
+  #map { flex:1; z-index:1; min-height:0; }
+  .leaflet-tile-pane { filter: var(--tile-filter); transition: filter 0.3s; }
+  .leaflet-popup-content-wrapper { font-family:'JetBrains Mono',monospace!important; font-size:11px!important; border-radius:10px!important; box-shadow:0 8px 32px rgba(0,0,0,0.15)!important; background:var(--surface)!important; color:var(--text)!important; border:1px solid var(--border)!important; }
+  .leaflet-popup-tip { background:var(--surface)!important; }
+  .popup-title { font-family:'Syne',sans-serif; font-size:13px; font-weight:700; color:var(--text); margin-bottom:7px; }
+  .popup-row { display:flex; justify-content:space-between; padding:3px 0; border-bottom:1px solid var(--border); gap:12px; }
+  .popup-row:last-child { border-bottom:none; }
+  .popup-key   { color:var(--muted); }
+  .popup-value { color:var(--text); font-weight:500; }
+
+  /* ── Playback bar ── */
+  .playback-bar { background:var(--surface); border-top:1px solid var(--border); padding:10px 16px; display:flex; align-items:center; gap:12px; flex-shrink:0; z-index:100; }
+  .play-btn { width:32px; height:32px; border-radius:50%; background:var(--accent); border:none; color:white; cursor:pointer; display:flex; align-items:center; justify-content:center; font-size:14px; transition:all 0.2s; flex-shrink:0; }
+  .play-btn:hover:not(:disabled) { background:#2563eb; transform:scale(1.05); }
+  .play-btn:disabled { background:var(--border); cursor:not-allowed; }
+  .playback-info { font-size:11px; color:var(--muted); flex-shrink:0; min-width:90px; }
+  .progress-wrap { flex:1; position:relative; padding:6px 0; cursor:pointer; }
+  .progress-track { width:100%; height:4px; background:var(--border); border-radius:2px; position:relative; }
+  .progress-fill  { height:100%; background:var(--accent); border-radius:2px; pointer-events:none; }
+  .progress-thumb { width:12px; height:12px; border-radius:50%; background:var(--accent); border:2px solid var(--surface); box-shadow:0 1px 4px rgba(0,0,0,0.25); position:absolute; top:50%; transform:translate(-50%,-50%); pointer-events:none; }
+
+  /* Round tick marks on progress bar */
+  .round-ticks { position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none; }
+  .round-tick  { position:absolute; top:0; width:1px; height:100%; background:rgba(59,130,246,0.3); }
+
+  .speed-select { background:var(--bg); border:1px solid var(--border); border-radius:6px; padding:4px 8px; font-size:10px; font-family:'JetBrains Mono',monospace; color:var(--text); cursor:pointer; }
+  .playback-mode { font-size:10px; color:var(--muted); flex-shrink:0; }
+  .playback-mode.replay { color:var(--orange); font-weight:600; }
+
+  /* ── Log panel ── */
+  .log-panel { position:absolute; bottom:16px; right:16px; width:290px; background:var(--surface); border:1px solid var(--border); border-radius:10px; z-index:999; overflow:hidden; box-shadow:0 4px 20px rgba(0,0,0,0.12); opacity:0.95; }
+  .log-header { padding:8px 12px; border-bottom:1px solid var(--border); font-size:9px; letter-spacing:1px; text-transform:uppercase; color:var(--muted); display:flex; justify-content:space-between; }
+  .log-entries { max-height:110px; overflow-y:auto; padding:6px; }
+  .log-entries::-webkit-scrollbar { width:3px; }
+  .log-entries::-webkit-scrollbar-thumb { background:var(--border); }
+  .log-entry { font-size:10px; padding:3px 6px; border-radius:4px; margin-bottom:2px; display:flex; gap:8px; animation:fadeIn 0.3s ease; }
+  @keyframes fadeIn { from{opacity:0;transform:translateY(3px)} to{opacity:1;transform:none} }
+  .log-entry .ts  { color:var(--muted); flex-shrink:0; }
+  .log-entry .msg { color:var(--text); }
+  .log-entry.update { border-left:2px solid var(--accent); }
+  .log-entry.round  { border-left:2px solid var(--green); }
+  .log-entry.drop   { border-left:2px solid var(--red); }
+
+  #debug { position:absolute; top:16px; right:16px; background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:8px 12px; font-size:10px; color:var(--muted); z-index:999; box-shadow:0 2px 8px rgba(0,0,0,0.08); opacity:0.9; }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="logo">
+    <div class="logo-mark">fv</div>
+    <div>
+      <div class="logo-text">FedViz</div>
+      <div class="logo-sub">Federated Client Map</div>
+    </div>
+  </div>
+  <div class="header-stats">
+    <div class="stat"><div class="stat-val" id="hdr-round">—</div><div class="stat-label">Round</div></div>
+    <div class="stat"><div class="stat-val" id="hdr-clients">0</div><div class="stat-label">Active Clients</div></div>
+    <div class="stat"><div class="stat-val" id="hdr-acc">—</div><div class="stat-label">Global Acc</div></div>
+    <div class="stat"><div class="stat-val" id="hdr-loss">—</div><div class="stat-label">Global Loss</div></div>
+  </div>
+  <div class="header-right">
+    <div class="status-pill">
+      <div class="status-dot" id="status-dot"></div>
+      <span id="status-text">connecting…</span>
+    </div>
+    <button class="theme-btn" onclick="toggleTheme()" id="theme-btn" title="Toggle dark mode">🌙</button>
+  </div>
+</header>
+
+<div class="main">
+
+  <!-- Runs panel -->
+  <div class="runs-panel">
+    <div class="runs-panel-header">
+      <span>Runs</span>
+      <button class="refresh-btn" onclick="loadRuns()" title="Refresh">↻</button>
+    </div>
+    <div class="runs-list" id="runs-list">
+      <div style="color:var(--muted);font-size:10px;padding:12px;text-align:center;">Loading…</div>
+    </div>
+  </div>
+
+  <!-- Sidebar -->
+  <div class="sidebar">
+    <div class="sidebar-section">
+      <div class="section-title">Round Summary</div>
+      <div class="round-info">
+        <div class="round-stat"><div class="val" id="sb-round">—</div><div class="lbl">Round</div></div>
+        <div class="round-stat"><div class="val" id="sb-participants">—</div><div class="lbl">Participants</div></div>
+        <div class="round-stat"><div class="val" id="sb-acc">—</div><div class="lbl">Accuracy</div></div>
+        <div class="round-stat"><div class="val" id="sb-loss">—</div><div class="lbl">Loss</div></div>
+      </div>
+    </div>
+    <div class="sidebar-section" style="padding-bottom:8px;">
+      <div class="section-title">Clients</div>
+    </div>
+    <div class="client-list" id="client-list">
+      <div style="color:var(--muted);font-size:11px;padding:12px;text-align:center;">Waiting for clients…</div>
+    </div>
+  </div>
+
+  <!-- Map + playback -->
+  <div class="map-area">
+    <div id="map"></div>
+
+    <div id="debug">
+      SSE: <span id="dbg-sse" style="color:var(--red)">disconnected</span><br>
+      Last event: <span id="dbg-last">none</span><br>
+      Events received: <span id="dbg-count">0</span>
+    </div>
+
+    <div class="log-panel">
+      <div class="log-header">
+        <span>Event Log</span>
+        <span id="log-count">0 events</span>
+      </div>
+      <div class="log-entries" id="log-entries"></div>
+    </div>
+
+    <!-- Playback bar -->
+    <div class="playback-bar">
+      <button class="play-btn" id="play-btn" onclick="togglePlay()" disabled>▶</button>
+      <div class="playback-info" id="playback-info">No run selected</div>
+      <div class="progress-wrap" onclick="seekTo(event)">
+        <div class="progress-track" id="progress-track">
+          <div class="progress-fill"  id="progress-fill"  style="width:0%"></div>
+          <div class="round-ticks"    id="round-ticks"></div>
+          <div class="progress-thumb" id="progress-thumb" style="left:0%"></div>
+        </div>
+      </div>
+      <select class="speed-select" id="speed-select" onchange="setSpeed(this.value)">
+        <option value="2000">0.5×</option>
+        <option value="1000" selected>1×</option>
+        <option value="500">2×</option>
+        <option value="200">5×</option>
+        <option value="50">10×</option>
+      </select>
+      <div class="playback-mode" id="playback-mode">live</div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.min.js"></script>
+<script>
+const params = new URLSearchParams(window.location.search);
+const defaultServer = window.location.origin && window.location.origin !== "null"
+  ? window.location.origin
+  : "http://localhost:7070";
+const SERVER       = params.get("server") || defaultServer;
+const SSE_URL      = `${SERVER}/stream`;
+const METADATA_URL = params.get("metadata_url");
+const EVENTS_URL   = params.get("events_url");
+const AUTO_RUN_ID  = params.get("run_id");
+
+// ── State ─────────────────────────────────────────────────────────────────────
+const state = {
+  clients:    {},
+  round:      0,
+  totalRounds:0,
+  globalAcc:  null,
+  globalLoss: null,
+  logCount:   0,
+  evtCount:   0,
+  mode:       "live",
+  liveRunId:  null,
+  staticLoaded: false,  // Flag to prevent duplicate playback loading
+  roundDurationMs: 4000,
+};
+
+// Playback — operates on ROUNDS, not raw events
+const pb = {
+  rounds:    [],    // array of round snapshots built from JSONL
+  events:    [],    // raw events (used in playback mode)
+  index:     0,     // current round index (0-based)
+  playing:   false,
+  timer:     null,
+  speed:     1000,
+  runId:     null,
+};
+
+// ── Theme ─────────────────────────────────────────────────────────────────────
+function toggleTheme() {
+  const html = document.documentElement;
+  const isDark = html.getAttribute("data-theme") === "dark";
+  html.setAttribute("data-theme", isDark ? "light" : "dark");
+  document.getElementById("theme-btn").textContent = isDark ? "🌙" : "☀️";
+}
+
+// ── Formatters ─────────────────────────────────────────────────────────────────
+function fmtAcc(val) {
+  if (val == null) return "—";
+  const pct = val <= 1.0 ? val * 100 : val;
+  return pct.toFixed(2) + "%";
+}
+function fmtLoss(val) {
+  if (val == null) return "—";
+  return parseFloat(val).toFixed(4);
+}
+
+// ── Map ───────────────────────────────────────────────────────────────────────
+const map = L.map("map", { center:[30,10], zoom:2 });
+L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+  attribution:"© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors",
+}).addTo(map);
+
+const ARGONNE_SERVER = {
+  lat: 41.7136,
+  lng: -87.9959,
+  institution: "Argonne National Lab",
+  city: "Lemont",
+  region: "IL",
+  country: "USA",
+  protocol: "gRPC / APPFL",
+  host: "argonne.gov",
+  fallback: true,
+};
+let SERVER_LL = [ARGONNE_SERVER.lat, ARGONNE_SERVER.lng];
+const serverIcon = L.divIcon({
+  className:"",
+  html:`<div style="width:20px;height:20px;background:#f59e0b;border:3px solid white;border-radius:50%;box-shadow:0 0 0 4px rgba(245,158,11,0.25),0 2px 8px rgba(0,0,0,0.3);"></div>`,
+  iconSize:[20,20], iconAnchor:[10,10],
+});
+let serverMarker = null;
+
+function isLocalHost(host) {
+  return !host || ["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"].includes(host);
+}
+
+function getServerHost() {
+  try {
+    return new URL(SERVER).hostname;
+  } catch (_) {
+    return "";
+  }
+}
+
+function buildServerPopup(server) {
+  const location = [server.city, server.region, server.country].filter(Boolean).join(", ") || "Unknown";
+  const institution = server.fallback ? ARGONNE_SERVER.institution : (server.org || server.host || "Resolved from server IP");
+  return `
+    <div class="popup-title">🖥 FL Server</div>
+    <div class="popup-row"><span class="popup-key">Institution</span><span class="popup-value">${institution}</span></div>
+    <div class="popup-row"><span class="popup-key">Location</span><span class="popup-value">${location}</span></div>
+    <div class="popup-row"><span class="popup-key">Protocol</span><span class="popup-value">${server.protocol || "gRPC / APPFL"}</span></div>
+  `;
+}
+
+function renderServerMarker(server) {
+  SERVER_LL = [server.lat, server.lng];
+  const popup = buildServerPopup(server);
+  if (serverMarker) {
+    serverMarker.setLatLng(SERVER_LL).setPopupContent(popup);
+  } else {
+    serverMarker = L.marker(SERVER_LL, {icon:serverIcon, zIndexOffset:1000})
+      .bindPopup(popup)
+      .addTo(map);
+  }
+
+  Object.entries(lines).forEach(([id, line]) => {
+    const client = state.clients[id];
+    if (client?.lat && client?.lng) line.setLatLngs([[client.lat, client.lng], SERVER_LL]);
+  });
+}
+
+async function resolveServerLocation() {
+  const host = getServerHost();
+  if (isLocalHost(host)) {
+    renderServerMarker(ARGONNE_SERVER);
+    return;
+  }
+
+  try {
+    const res = await fetch(`https://ipinfo.io/${host}/json`);
+    if (!res.ok) throw new Error(`geo lookup failed: ${res.status}`);
+    const data = await res.json();
+    if (!data.loc) throw new Error("missing location");
+    const [lat, lng] = data.loc.split(",").map(Number);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) throw new Error("invalid coordinates");
+
+    renderServerMarker({
+      lat,
+      lng,
+      city: data.city || "Unknown",
+      region: data.region || "",
+      country: data.country || "Unknown",
+      org: data.org || "Resolved from server IP",
+      protocol: "gRPC / APPFL",
+      host,
+      fallback: false,
+    });
+  } catch (_) {
+    renderServerMarker(ARGONNE_SERVER);
+  }
+}
+
+const markers = {};
+const lines   = {};
+const packets = {};
+const networkAnim = {
+  frame: null,
+  startedAt: 0,
+  cycleMs: state.roundDurationMs,
+};
+
+function accColor(acc) {
+  if (acc == null) return "#3b82f6";
+  const pct = acc <= 1.0 ? acc * 100 : acc;
+  if (pct >= 80) return "#10b981";
+  if (pct >= 60) return "#3b82f6";
+  return "#ef4444";
+}
+
+function lerpLatLng(from, to, t) {
+  return [
+    from[0] + (to[0] - from[0]) * t,
+    from[1] + (to[1] - from[1]) * t,
+  ];
+}
+
+function pingPong(t) {
+  return t < 0.5 ? t * 2 : (1 - t) * 2;
+}
+
+function ensureClientPackets(id, ll, color) {
+  const uplinkColor = color || "#38bdf8";
+  const downlinkColor = "#f59e0b";
+  if (!packets[id]) {
+    packets[id] = {
+      uplink: L.circleMarker(ll, {
+        radius: 5,
+        color: "#ffffff",
+        weight: 1.2,
+        fillColor: uplinkColor,
+        fillOpacity: 0.95,
+        opacity: 1,
+      }).addTo(map),
+      downlink: L.circleMarker(ll, {
+        radius: 5,
+        color: "#ffffff",
+        weight: 1.2,
+        fillColor: downlinkColor,
+        fillOpacity: 0.95,
+        opacity: 1,
+      }).addTo(map),
+    };
+  }
+  packets[id].uplink.setStyle({ fillColor: uplinkColor }).setLatLng(ll);
+  packets[id].downlink.setStyle({ fillColor: downlinkColor }).setLatLng(ll);
+}
+
+function stopNetworkAnimation() {
+  if (networkAnim.frame) {
+    cancelAnimationFrame(networkAnim.frame);
+    networkAnim.frame = null;
+  }
+}
+
+function animateNetworkTraffic(now) {
+  const activeIds = Object.keys(lines).filter(id => state.clients[id]?.lat && state.clients[id]?.lng);
+  if (!activeIds.length) {
+    networkAnim.frame = null;
+    return;
+  }
+
+  const cycle = ((now - networkAnim.startedAt) % networkAnim.cycleMs) / networkAnim.cycleMs;
+  const uploadProgress = pingPong(cycle);
+  const downloadProgress = pingPong((cycle + 0.5) % 1);
+
+  activeIds.forEach(id => {
+    const client = state.clients[id];
+    const ll = [client.lat, client.lng];
+    ensureClientPackets(id, ll, accColor(client.local_accuracy));
+    packets[id].uplink.setLatLng(lerpLatLng(ll, SERVER_LL, uploadProgress));
+    packets[id].downlink.setLatLng(lerpLatLng(SERVER_LL, ll, downloadProgress));
+  });
+
+  networkAnim.frame = requestAnimationFrame(animateNetworkTraffic);
+}
+
+function syncNetworkAnimation(durationMs) {
+  networkAnim.cycleMs = Math.max(1200, durationMs || state.roundDurationMs || 4000);
+  networkAnim.startedAt = performance.now();
+  stopNetworkAnimation();
+  networkAnim.frame = requestAnimationFrame(animateNetworkTraffic);
+}
+
+function upsertClient(id, data) {
+  state.clients[id] = Object.assign(state.clients[id] || {}, data);
+  const c = state.clients[id];
+  if (!c.lat || !c.lng) return;
+
+  const ll  = [c.lat, c.lng];
+  const col = accColor(c.local_accuracy);
+
+  const icon = L.divIcon({
+    className:"",
+    html:`<div style="width:14px;height:14px;border-radius:50%;background:${col};border:2.5px solid white;box-shadow:0 0 0 3px ${col}44,0 2px 6px rgba(0,0,0,0.2);"></div>`,
+    iconSize:[14,14], iconAnchor:[7,7],
+  });
+
+  const popup = `
+    <div class="popup-title">📡 ${id}</div>
+    <div class="popup-row"><span class="popup-key">Location</span><span class="popup-value">${c.city||"—"}, ${c.country||""}</span></div>
+    <div class="popup-row"><span class="popup-key">Accuracy</span><span class="popup-value">${fmtAcc(c.local_accuracy)}</span></div>
+    <div class="popup-row"><span class="popup-key">Loss</span><span class="popup-value">${fmtLoss(c.local_loss)}</span></div>
+    <div class="popup-row"><span class="popup-key">Samples</span><span class="popup-value">${c.num_samples||"—"}</span></div>
+    <div class="popup-row"><span class="popup-key">Status</span><span class="popup-value">${c.status||"active"}</span></div>
+  `;
+
+  if (markers[id]) {
+    markers[id].setLatLng(ll).setIcon(icon).setPopupContent(popup);
+    lines[id].setLatLngs([ll, SERVER_LL]).setStyle({
+      color: col,
+      weight: 2.8,
+      opacity: 0.82,
+      dashArray: "10 8",
+    });
+  } else {
+    markers[id] = L.marker(ll,{icon}).bindPopup(popup).addTo(map);
+    lines[id]   = L.polyline([ll,SERVER_LL],{color:col,weight:2.8,opacity:0.82,dashArray:"10 8"}).addTo(map);
+  }
+
+  ensureClientPackets(id, ll, col);
+}
+
+function clearMap() {
+  stopNetworkAnimation();
+  Object.values(markers).forEach(m => m.remove());
+  Object.values(lines).forEach(l => l.remove());
+  Object.values(packets).forEach(pair => {
+    pair.uplink.remove();
+    pair.downlink.remove();
+  });
+  Object.keys(markers).forEach(k => delete markers[k]);
+  Object.keys(lines).forEach(k => delete lines[k]);
+  Object.keys(packets).forEach(k => delete packets[k]);
+  Object.keys(state.clients).forEach(k => delete state.clients[k]);
+  state.round = 0; state.globalAcc = null; state.globalLoss = null;
+  renderSidebar();
+}
+
+// ── Sidebar ───────────────────────────────────────────────────────────────────
+function renderSidebar() {
+  const active = Object.values(state.clients).filter(c=>!c.status||c.status==="active").length;
+  document.getElementById("hdr-round").textContent   = state.round || "—";
+  document.getElementById("hdr-clients").textContent = active;
+  document.getElementById("hdr-acc").textContent     = fmtAcc(state.globalAcc);
+  document.getElementById("hdr-loss").textContent    = fmtLoss(state.globalLoss);
+  document.getElementById("sb-round").textContent    = state.round || "—";
+  document.getElementById("sb-participants").textContent = Object.keys(state.clients).length;
+  document.getElementById("sb-acc").textContent      = fmtAcc(state.globalAcc);
+  document.getElementById("sb-loss").textContent     = fmtLoss(state.globalLoss);
+
+  document.getElementById("client-list").innerHTML =
+    Object.entries(state.clients).map(([id,c])=>`
+      <div class="client-card" onclick="focusClient('${id}')">
+        <div class="client-header">
+          <span class="client-id">${id}</span>
+          <div class="client-badge ${c.status||'active'}"></div>
+        </div>
+        <div class="client-location">📍 ${c.city||"Unknown"}, ${c.country||""}</div>
+        <div class="client-metrics">
+          <div class="metric-chip"><span class="val">${fmtAcc(c.local_accuracy)}</span><br><span class="lbl">accuracy</span></div>
+          <div class="metric-chip"><span class="val">${fmtLoss(c.local_loss)}</span><br><span class="lbl">loss</span></div>
+          <div class="metric-chip"><span class="val">${c.num_samples||"—"}</span><br><span class="lbl">samples</span></div>
+          <div class="metric-chip"><span class="val">${c.gradient_norm!=null?parseFloat(c.gradient_norm).toFixed(2):"—"}</span><br><span class="lbl">grad norm</span></div>
+        </div>
+      </div>
+    `).join("") ||
+    '<div style="color:var(--muted);font-size:11px;padding:12px;text-align:center;">Waiting for clients…</div>';
+}
+
+function focusClient(id) {
+  const c = state.clients[id];
+  if (c?.lat && c?.lng) { map.flyTo([c.lat,c.lng],5,{duration:1.2}); markers[id]?.openPopup(); }
+}
+
+// ── Log ───────────────────────────────────────────────────────────────────────
+function addLog(msg, type="update") {
+  const now = new Date().toLocaleTimeString("en",{hour12:false});
+  const el  = document.getElementById("log-entries");
+  const div = document.createElement("div");
+  div.className = `log-entry ${type}`;
+  div.innerHTML = `<span class="ts">${now}</span><span class="msg">${msg}</span>`;
+  el.insertBefore(div, el.firstChild);
+  if (el.children.length > 50) el.removeChild(el.lastChild);
+  state.logCount++;
+  document.getElementById("log-count").textContent = `${state.logCount} events`;
+}
+
+// ── Debug ─────────────────────────────────────────────────────────────────────
+function dbg(status, lastEvt) {
+  const el = document.getElementById("dbg-sse");
+  el.textContent = status;
+  el.style.color = status==="connected"?"#10b981":"#ef4444";
+  if (lastEvt) document.getElementById("dbg-last").textContent = lastEvt;
+  document.getElementById("dbg-count").textContent = state.evtCount;
+}
+
+// ── Live event handler ────────────────────────────────────────────────────────
+function handleLiveEvent(msg) {
+  if (typeof msg === "string") {
+    try { msg = JSON.parse(msg); } catch(e) { return; }
+  }
+  state.evtCount++;
+  const type = msg.event_type;
+  dbg("connected", type);
+  if (type === "ping" || type === "connected") return;
+
+  if (type === "init")
+    addLog(`Run started — ${msg.algorithm||""}`, "round");
+
+  if (type === "round_end") {
+  const rm = msg.round_metrics || {};
+  
+  // In live mode accept all round_end events — last one wins
+ 
+  state.round      = msg.round      ?? state.round;
+  state.globalAcc  = rm.global_accuracy ?? state.globalAcc;
+  state.globalLoss = rm.global_loss     ?? state.globalLoss;
+  if (rm.round_duration_sec != null) state.roundDurationMs = Math.max(1200, rm.round_duration_sec * 1000);
+  
+  // Only update map if this event has clients
+  if (msg.clients && msg.clients.length > 0) {
+    (msg.clients||[]).forEach(c => upsertClient(c.client_id, c));
+    addLog(`Round ${state.round} — acc=${fmtAcc(state.globalAcc)}`, "round");
+  }
+  if (!networkAnim.frame) syncNetworkAnimation(state.roundDurationMs);
+  renderSidebar();
+}
+
+  if (type === "client_update") {
+  const c = (msg.clients||[])[0];
+  if (c) {
+    upsertClient(c.client_id, c);
+    addLog(`${c.client_id} — acc=${fmtAcc(c.local_accuracy)}`);
+    renderSidebar();  
+  }
+}
+
+  if (type === "round_start") {
+    state.round = msg.round ?? state.round;
+    syncNetworkAnimation(state.roundDurationMs);
+    addLog(`Round ${state.round} started`, "round");
+    renderSidebar();
+  }
+
+  if (type === "client_dropout") {
+    const c = (msg.clients||[])[0];
+    if (c) { upsertClient(c.client_id,{status:"dropped"}); addLog(`${c.client_id} dropped`,"drop"); renderSidebar(); }
+  }
+
+  if (type === "finished") addLog("Run finished", "round");
+}
+
+// ── Build round snapshots from raw JSONL events ───────────────────────────────
+// Groups all events by round number, keeps only the canonical round_end
+// (the one with clients populated, not the empty duplicate APPFL emits)
+function buildRounds(events) {
+  const byRound = {};
+
+  for (const evt of events) {
+    const rnd = evt.round;
+    if (rnd == null) continue;
+
+    if (!byRound[rnd]) byRound[rnd] = { round_end: null, clients: {} };
+
+    // Keep the round_end that has clients populated
+    if (evt.event_type === "round_end") {
+      const rm = evt.round_metrics || {};
+      const hasClients = evt.clients && evt.clients.length > 0;
+      const hasMetrics = rm.num_selected > 0;
+      if (hasClients || hasMetrics) {
+        byRound[rnd].round_end = evt;
+      }
+    }
+
+    // Accumulate per-client updates
+    if (evt.event_type === "client_update") {
+      const c = (evt.clients||[])[0];
+      if (c) byRound[rnd].clients[c.client_id] = c;
+    }
+  }
+
+  // Build sorted array of round snapshots
+  return Object.keys(byRound)
+    .map(Number)
+    .sort((a,b) => a - b)
+    .map(rnd => {
+      const d   = byRound[rnd];
+      const re  = d.round_end || {};
+      const rm  = re.round_metrics || {};
+      return {
+        round:        rnd,
+        globalAcc:    rm.global_accuracy,
+        globalLoss:   rm.global_loss,
+        duration:     rm.round_duration_sec,
+        divergence:   rm.gradient_divergence,
+        clients:      Object.values(d.clients),
+      };
+    });
+}
+
+// ── Apply a round snapshot to the map/sidebar ─────────────────────────────────
+function applyRound(snapshot) {
+  state.round      = snapshot.round;
+  state.globalAcc  = snapshot.globalAcc;
+  state.globalLoss = snapshot.globalLoss;
+  if (snapshot.duration != null) state.roundDurationMs = Math.max(1200, snapshot.duration * 1000);
+
+  snapshot.clients.forEach(c => upsertClient(c.client_id, c));
+  syncNetworkAnimation(state.roundDurationMs);
+
+  addLog(
+    `Round ${snapshot.round} — acc=${fmtAcc(snapshot.globalAcc)} loss=${fmtLoss(snapshot.globalLoss)}`,
+    "round"
+  );
+  renderSidebar();
+}
+
+// ── Runs panel ────────────────────────────────────────────────────────────────
+async function loadRuns() {
+  const el = document.getElementById("runs-list");
+  try {
+    const res  = await fetch(`${SERVER}/runs`);
+    const runs = await res.json();
+    if (!runs.length) {
+      el.innerHTML = '<div style="color:var(--muted);font-size:10px;padding:12px;text-align:center;">No runs yet</div>';
+      return;
+    }
+    el.innerHTML = runs.map(r => {
+      const isLive = r.run_id === state.liveRunId;
+      const date   = r.started_at
+        ? new Date(r.started_at).toLocaleString("en",{month:"short",day:"numeric",hour:"2-digit",minute:"2-digit"})
+        : "";
+      return `
+        <div class="run-item ${isLive?"live-run":""}" onclick="selectRun('${r.run_id}', ${isLive}, event)">
+          <div class="run-id-text">
+            ${r.run_id.replace("run-","")}
+            <span class="run-badge ${isLive?"live":"done"}">${isLive?"live":"done"}</span>
+          </div>
+          <div class="run-meta">${r.algorithm}</div>
+          <div class="run-meta">${date}</div>
+        </div>
+      `;
+    }).join("");
+  } catch(e) {
+    el.innerHTML = '<div style="color:var(--red);font-size:10px;padding:12px;text-align:center;">Server unreachable</div>';
+  }
+}
+
+async function selectRun(runId, isLive, evt) {
+  document.querySelectorAll(".run-item").forEach(el => el.classList.remove("active"));
+  if (evt?.currentTarget) evt.currentTarget.classList.add("active");
+
+  if (isLive) { setMode("live"); return; }
+
+  setMode("replay");
+  clearMap();
+  stopPlayback();
+  pb.runId   = runId;
+  pb.index   = 0;
+  pb.rounds  = [];
+
+  try {
+    let metadata = null;
+    try {
+      const metadataRes = await fetch(`${SERVER}/runs/${runId}/metadata`);
+      if (metadataRes.ok) metadata = await metadataRes.json();
+    } catch(_) {}
+
+    if (metadata?.rounds?.length) {
+      pb.rounds = metadata.rounds;
+    } else {
+      const res    = await fetch(`${SERVER}/runs/${runId}/events`);
+      const events = await res.json();
+      pb.rounds    = buildRounds(events);
+    }
+    state.totalRounds = pb.rounds.length;
+
+    document.getElementById("play-btn").disabled = pb.rounds.length === 0;
+    document.getElementById("playback-mode").textContent = `replay · ${runId.replace("run-","")}`;
+    document.getElementById("playback-mode").className   = "playback-mode replay";
+    buildRoundTicks();
+    updateProgress();
+    addLog(`Loaded run ${runId} — ${pb.rounds.length} rounds`, "round");
+  } catch(e) {
+    addLog(`Failed to load run ${runId}`, "drop");
+  }
+}
+
+async function loadRunFromSource({ metadataUrl, eventsUrl, runId }) {
+  setMode("replay");
+  clearMap();
+  stopPlayback();
+  pb.runId  = runId || "external";
+  pb.index  = 0;
+  pb.rounds = [];
+
+  if (metadataUrl) {
+    const res = await fetch(metadataUrl);
+    const metadata = await res.json();
+    pb.rounds = metadata?.rounds || [];
+  } else if (eventsUrl) {
+    const res = await fetch(eventsUrl);
+    const events = await res.json();
+    pb.rounds = buildRounds(events);
+  }
+
+  state.totalRounds = pb.rounds.length;
+  document.getElementById("play-btn").disabled = pb.rounds.length === 0;
+  document.getElementById("playback-mode").textContent = `replay · ${pb.runId}`;
+  document.getElementById("playback-mode").className   = "playback-mode replay";
+  buildRoundTicks();
+  updateProgress();
+  addLog(`Loaded ${pb.rounds.length} rounds from external source`, "round");
+}
+
+function setMode(mode) {
+  state.mode = mode;
+  if (mode === "live") {
+    document.getElementById("playback-mode").textContent = "live";
+    document.getElementById("playback-mode").className   = "playback-mode";
+    document.getElementById("play-btn").disabled = true;
+    document.getElementById("playback-info").textContent = "Live mode";
+    stopPlayback();
+  } else if (mode === "playback") {
+    document.getElementById("playback-mode").textContent = "playback";
+    document.getElementById("playback-mode").className   = "playback-mode playback";
+    document.getElementById("play-btn").disabled = false;
+    document.getElementById("playback-info").textContent = "Playback mode";
+  }
+}
+
+// ── Playback ──────────────────────────────────────────────────────────────────
+function togglePlay() {
+  pb.playing ? stopPlayback() : startPlayback();
+}
+
+function getPlaybackDelay(snapshot) {
+  const base = snapshot?.duration != null ? Math.max(250, snapshot.duration * 1000) : 1000;
+  return Math.max(50, Math.round(base * (pb.speed / 1000)));
+}
+
+function startPlayback() {
+  if (!pb.rounds.length) return;
+  // If at end, restart from beginning
+  if (pb.index >= pb.rounds.length) { clearMap(); pb.index = 0; }
+  pb.playing = true;
+  document.getElementById("play-btn").textContent = "⏸";
+  stepPlayback();
+}
+
+function stopPlayback() {
+  pb.playing = false;
+  document.getElementById("play-btn").textContent = "▶";
+  if (pb.timer) { clearTimeout(pb.timer); pb.timer = null; }
+  stopNetworkAnimation();
+}
+
+function stepPlayback() {
+  if (!pb.playing) return;
+  if (pb.index >= pb.rounds.length) {
+    stopPlayback();
+    addLog("Replay finished ✓", "round");
+    return;
+  }
+  const snapshot = pb.rounds[pb.index];
+  applyRound(snapshot);
+  pb.index++;
+  updateProgress();
+  pb.timer = setTimeout(stepPlayback, getPlaybackDelay(snapshot));
+}
+
+function updateProgress() {
+  const total = pb.rounds.length || 1;
+  const pct   = pb.index / total * 100;
+  document.getElementById("progress-fill").style.width = pct + "%";
+  document.getElementById("progress-thumb").style.left = pct + "%";
+
+  const cur = pb.index;
+  const tot = pb.rounds.length;
+  document.getElementById("playback-info").textContent =
+    tot ? `Round ${cur} / ${tot}` : "No run selected";
+}
+
+function buildRoundTicks() {
+  const container = document.getElementById("round-ticks");
+  container.innerHTML = "";
+  const total = pb.rounds.length;
+  pb.rounds.forEach((_, i) => {
+    const tick = document.createElement("div");
+    tick.className = "round-tick";
+    tick.style.left = (i / total * 100) + "%";
+    container.appendChild(tick);
+  });
+}
+
+function seekTo(e) {
+  if (!pb.rounds.length) return;
+  const track = document.getElementById("progress-track");
+  const rect  = track.getBoundingClientRect();
+  const pct   = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+  const idx   = Math.floor(pct * pb.rounds.length);
+
+  stopPlayback();
+  clearMap();
+  pb.index = 0;
+  for (let i = 0; i < idx; i++) applyRound(pb.rounds[i]);
+  pb.index = idx;
+  updateProgress();
+}
+
+function setSpeed(val) { pb.speed = parseInt(val); }
+
+// ── SSE ───────────────────────────────────────────────────────────────────────
+function connect() {
+  const es = new EventSource(SSE_URL);
+
+  es.onopen = () => {
+    dbg("connected", "—");
+    document.getElementById("status-dot").classList.add("live");
+    document.getElementById("status-text").textContent = "live";
+    addLog("Connected to fedviz server", "round");
+    loadRuns();
+  };
+
+  es.onmessage = (e) => {
+    try {
+      const msg = JSON.parse(e.data);
+
+      if (msg.event_type === "init" && msg.run_id) {
+        state.liveRunId = msg.run_id;
+        // Clear map for new run
+        clearMap();
+        // Only set live mode if explicitly in live mode, otherwise static playback
+        if (msg.mode === "live") {
+          setMode("live");
+          state.staticLoaded = false;
+          addLog(`Live run started: ${msg.run_id}`, "round");
+        } else {
+          setMode("playback");
+          state.staticLoaded = false; // Allow loading
+          addLog(`Static run loaded: ${msg.run_id}`, "round");
+          pb.events = []; // Reset events array for new playback
+          pb.rounds = []; // Reset rounds
+          pb.index = 0;
+          pb.playing = false;
+        }
+        loadRuns();   // refresh panel to show new run
+      }
+
+      if (state.mode === "live") {
+        handleLiveEvent(msg);
+      } else if (state.mode === "playback" && !state.staticLoaded) {
+        // In playback mode, collect events (skip init and connection messages)
+        if (msg.event_type && msg.event_type !== "connected" && msg.event_type !== "ping" && msg.event_type !== "init") {
+          pb.events.push(msg);
+        }
+        // When finished, build rounds and show first
+        if (msg.event_type === "finished") {
+          state.staticLoaded = true; // Mark as loaded to prevent duplicates
+          console.log(`[DEBUG] Events collected: ${pb.events.length}`);
+          pb.rounds = buildRounds(pb.events);
+          console.log(`[DEBUG] Rounds built: ${pb.rounds.length}`);
+          if (pb.rounds.length > 0) {
+            pb.index = 0;
+            applyRound(pb.rounds[0]);
+            updateProgress();
+            addLog(`Loaded ${pb.rounds.length} rounds — ready to play`, "round");
+            // Auto-start playback after a small delay to ensure UI is updated
+            setTimeout(() => startPlayback(), 100);
+          }
+        }
+      }
+
+    } catch(_) {}
+  };
+
+  es.onerror = () => {
+    dbg("disconnected");
+    document.getElementById("status-dot").classList.remove("live");
+    document.getElementById("status-text").textContent = "reconnecting…";
+    es.close();
+    // Only reconnect in live mode, not in static playback
+    if (state.mode === "live") {
+      setTimeout(connect, 3000);
+    }
+  };
+}
+resolveServerLocation();
+
+if (METADATA_URL || EVENTS_URL) {
+  loadRunFromSource({
+    metadataUrl: METADATA_URL,
+    eventsUrl: EVENTS_URL,
+    runId: AUTO_RUN_ID,
+  }).catch(() => addLog("Failed to load external run source", "drop"));
+} else {
+  connect();
+  loadRuns().then(() => {
+    if (AUTO_RUN_ID) {
+      selectRun(AUTO_RUN_ID, false, null).catch(() => addLog(`Failed to auto-load run ${AUTO_RUN_ID}`, "drop"));
+    }
+  });
+}
+</script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.8"
 
+[project.scripts]
+hivewatch = "fedviz.cli:main"
+fedviz = "fedviz.cli:main"
+
 [project.optional-dependencies]
 wandb  = ["wandb>=0.16"]
 mlflow = ["mlflow>=2.0"]

--- a/src/fedviz/__main__.py
+++ b/src/fedviz/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+
+raise SystemExit(main())

--- a/src/fedviz/cli.py
+++ b/src/fedviz/cli.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import argparse
+
+from .map_server import MapServer
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hivewatch")
+    subparsers = parser.add_subparsers(dest="command")
+
+    map_parser = subparsers.add_parser("map", help="Map dashboard commands")
+    map_subparsers = map_parser.add_subparsers(dest="map_command")
+
+    run_parser = map_subparsers.add_parser("run", help="Serve the map dashboard")
+    run_parser.add_argument("--host", default="0.0.0.0", help="Host to bind")
+    run_parser.add_argument("--port", type=int, default=7070, help="Port to bind")
+    run_parser.add_argument("--runs-dir", default="runs", help="Directory containing *.jsonl/*.map.json")
+    run_parser.add_argument("--run-id", default=None, help="Load a specific run (by ID or filename)")
+    run_parser.add_argument("--map-path", default=None, help="Optional path to fedviz_map.html")
+    run_parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=1.0,
+        help="How often to poll the runs directory for updates",
+    )
+
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "map" and args.map_command == "run":
+        # Disable watch mode when loading a specific run
+        watch_mode = args.run_id
+        
+        server = MapServer(
+            host=args.host,
+            port=args.port,
+            runs_dir=args.runs_dir,
+            run_id=args.run_id,
+            map_path=args.map_path,
+            watch=watch_mode,
+            poll_interval=args.poll_interval,
+        )
+        server.start()
+        print(f"[hivewatch] map dashboard -> http://localhost:{args.port}")
+        print(f"[hivewatch] runs directory -> {args.runs_dir}")
+        if args.run_id:
+            print(f"[hivewatch] loading run -> {args.run_id} (static mode)")
+        else:
+            print(f"[hivewatch] watching for live updates")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            server.stop()
+        return 0
+
+    parser.print_help()
+    return 1

--- a/src/fedviz/emitters/__init__.py
+++ b/src/fedviz/emitters/__init__.py
@@ -1,5 +1,6 @@
+from .sse_emitter import SSEEmitter
 
 from .wandb_emitter import WandbEmitter
 from .mlflow_emitter import MLflowEmitter
  
-__all__ = ["WandbEmitter", "MLflowEmitter"]
+__all__ = ["WandbEmitter", "MLflowEmitter", "SSEEmitter"]

--- a/src/fedviz/emitters/sse_emitter.py
+++ b/src/fedviz/emitters/sse_emitter.py
@@ -1,0 +1,298 @@
+"""
+fedviz.emitters.sse_emitter
+────────────────────────────
+Starts a lightweight HTTP server that:
+  1. Streams live fedviz events to the map dashboard via SSE (GET /stream)
+  2. Persists every event to runs/<run_id>.jsonl for history replay
+  3. Persists map-ready metadata to runs/<run_id>.map.json for deferred reloads
+  4. Serves run history endpoints:
+       GET /runs                    → list of all past runs
+       GET /runs/<run_id>/events    → all events for a run (for replay)
+       GET /runs/<run_id>/metadata  → map metadata for a run
+       GET /                        → serves fedviz_map.html
+
+Directory structure:
+    runs/
+      run-abcd-1234.jsonl     ← one JSON event per line, appended live
+      run-abcd-1234.map.json  ← self-contained map metadata
+      run-efgh-5678.jsonl
+      ...
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from ..map_server import MapServer
+from ..map_metadata import merge_client_state
+from ..schema import ClientUpdate, RoundSummary
+
+logger = logging.getLogger("fedviz.emitters.sse")
+
+
+class SSEEmitter:
+    """
+    Emitter that broadcasts fedviz events over SSE and persists to JSONL files.
+    """
+
+    def __init__(
+        self,
+        host:     str  = "0.0.0.0",
+        port:     int  = 7070,
+        runs_dir: str  = "runs",
+        map_path: Optional[str] = None,   # path to fedviz_map.html
+        serve_map: bool = True,
+    ):
+        self.host     = host
+        self.port     = port
+        self.runs_dir = Path(runs_dir)
+        self.map_path = map_path          # if None, serves a placeholder
+        self.serve_map = serve_map
+        self.run_id:  Optional[str] = None
+        self._jsonl:  Optional[object]   = None   # open file handle
+        self._metadata_path: Optional[Path] = None
+        self._map_metadata: Optional[dict] = None
+        self._lock    = threading.Lock()
+        self._server: Optional[MapServer] = None
+
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Emitter hooks ─────────────────────────────────────────────────────────
+
+    def on_init(self, run_id: str, algorithm: str, config: dict):
+        self.run_id = run_id
+        # Open JSONL file for this run
+        jsonl_path  = self.runs_dir / f"{run_id}.jsonl"
+        self._metadata_path = self.runs_dir / f"{run_id}.map.json"
+        self._jsonl = open(jsonl_path, "a", encoding="utf-8")
+
+        # Write run header as first line
+        
+        header = {
+            "event_type": "init",
+            "run_id":     run_id,
+            "algorithm":  algorithm,
+            "config":     config,
+            "started_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._map_metadata = {
+            "schema_version": 1,
+            "run_id": run_id,
+            "algorithm": algorithm,
+            "config": config,
+            "started_at": header["started_at"],
+            "finished_at": None,
+            "rounds": [],
+        }
+        self._append(header)
+        self._write_metadata()
+        if self.serve_map:
+            self._start_server()
+        self._broadcast(header)
+
+        print(f"[fedviz/sse] run={run_id}")
+        print(f"[fedviz/sse] history → {jsonl_path}")
+        if self.serve_map:
+            print(f"[fedviz/sse] dashboard → http://localhost:{self.port}")
+        else:
+            print(f"[fedviz/sse] dashboard disabled; run `hivewatch map run --runs-dir {self.runs_dir}` to serve the map")
+
+    def on_round(self, summary: RoundSummary, clients: List[ClientUpdate]):
+        payload = {
+            "event_type":    "round_end",
+            "run_id":        self.run_id,
+            "round":         summary.round,
+            "timestamp":     datetime.now(timezone.utc).isoformat(),
+            "round_metrics": {
+                "global_accuracy":     summary.global_accuracy,
+                "global_loss":         summary.global_loss,
+                "num_selected":        summary.num_selected,
+                "num_completed":       summary.num_completed,
+                "num_stragglers":      summary.num_stragglers,
+                "round_duration_sec":  summary.round_duration_sec,
+                "gradient_divergence": summary.gradient_divergence,
+            },
+            "clients": [self._client_dict(c) for c in clients],
+        }
+        round_state = self._ensure_round_state(summary.round)
+        round_state["globalAcc"] = summary.global_accuracy
+        round_state["globalLoss"] = summary.global_loss
+        round_state["duration"] = summary.round_duration_sec
+        round_state["divergence"] = summary.gradient_divergence
+        for client in clients:
+            self._upsert_client(summary.round, self._client_dict(client))
+        self._append(payload)
+        self._write_metadata()
+        self._broadcast(payload)
+
+    def on_client_update(self, client: ClientUpdate):
+        payload = {
+            "event_type": "client_update",
+            "run_id":     self.run_id,
+            "round":      client.round,
+            "timestamp":  datetime.now(timezone.utc).isoformat(),
+            "clients":    [self._client_dict(client)],
+        }
+        if client.round is not None:
+            self._upsert_client(client.round, self._client_dict(client))
+        self._append(payload)
+        self._write_metadata()
+        self._broadcast(payload)
+
+    def on_dropout(self, round: int, client_id: str, reason: Optional[str]):
+        payload = {
+            "event_type": "client_dropout",
+            "run_id":     self.run_id,
+            "round":      round,
+            "timestamp":  datetime.now(timezone.utc).isoformat(),
+            "clients":    [{"client_id": client_id, "status": "dropped"}],
+            "reason":     reason or "unknown",
+        }
+        if round is not None:
+            self._upsert_client(round, {"client_id": client_id, "status": "dropped"})
+        self._append(payload)
+        self._write_metadata()
+        self._broadcast(payload)
+
+    def on_comm_failure(self, round: int, client_id: str, reason: Optional[str]):
+        payload = {
+            "event_type": "comm_failure",
+            "run_id":     self.run_id,
+            "round":      round,
+            "timestamp":  datetime.now(timezone.utc).isoformat(),
+            "client_id":  client_id,
+            "reason":     reason or "unknown",
+        }
+        if round is not None:
+            self._upsert_client(round, {"client_id": client_id, "status": "failed"})
+        self._append(payload)
+        self._write_metadata()
+        self._broadcast(payload)
+
+    def on_checkpoint(self, round: int, path: str, metadata: dict):
+        payload = {
+            "event_type": "checkpoint",
+            "run_id":     self.run_id,
+            "round":      round,
+            "timestamp":  datetime.now(timezone.utc).isoformat(),
+            "path":       path,
+        }
+        self._append(payload)
+        self._write_metadata()
+        self._broadcast(payload)
+
+    def finish(self):
+        payload = {
+            "event_type":  "finished",
+            "run_id":      self.run_id,
+            "timestamp":   datetime.now(timezone.utc).isoformat(),
+        }
+        if self._map_metadata is not None:
+            self._map_metadata["finished_at"] = payload["timestamp"]
+        self._append(payload)
+        self._write_metadata()
+        self._broadcast(payload)
+
+        if self._jsonl:
+            self._jsonl.close()
+            self._jsonl = None
+
+        if self._server:
+            # Keep server alive so dashboard can still load history
+            # It runs as a daemon thread so it dies with the process
+            pass
+
+    # ── Persistence ───────────────────────────────────────────────────────────
+
+    def _append(self, payload: dict):
+        if self._jsonl is None:
+            return
+        with self._lock:
+            self._jsonl.write(json.dumps(payload) + "\n")
+            self._jsonl.flush()
+
+    def _ensure_round_state(self, round_num: int) -> dict:
+        if self._map_metadata is None:
+            raise RuntimeError("map metadata not initialized")
+
+        rounds = self._map_metadata["rounds"]
+        for round_state in rounds:
+            if round_state["round"] == round_num:
+                return round_state
+
+        round_state = {
+            "round": round_num,
+            "globalAcc": None,
+            "globalLoss": None,
+            "duration": None,
+            "divergence": None,
+            "clients": [],
+        }
+        rounds.append(round_state)
+        rounds.sort(key=lambda item: item["round"])
+        return round_state
+
+    def _upsert_client(self, round_num: int, client: dict):
+        round_state = self._ensure_round_state(round_num)
+        clients = {item["client_id"]: item for item in round_state["clients"] if item.get("client_id")}
+        client_id = client.get("client_id")
+        if not client_id:
+            return
+        clients[client_id] = merge_client_state(clients.get(client_id), client)
+        round_state["clients"] = list(clients.values())
+
+    def _write_metadata(self):
+        if self._metadata_path is None or self._map_metadata is None:
+            return
+        with self._lock:
+            self._metadata_path.write_text(
+                json.dumps(self._map_metadata, indent=2) + "\n",
+                encoding="utf-8",
+            )
+
+    # ── SSE broadcast ─────────────────────────────────────────────────────────
+
+    def _broadcast(self, payload: dict):
+        if self._server is not None:
+            self._server.publish(payload)
+
+    # ── HTTP server ───────────────────────────────────────────────────────────
+
+    def _start_server(self):
+        if self._server is not None:
+            return
+
+        self._server = MapServer(
+            host=self.host,
+            port=self.port,
+            runs_dir=str(self.runs_dir),
+            map_path=self.map_path,
+            watch=False,
+        )
+        self._server.start()
+
+    # ── Client dict ───────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _client_dict(c: ClientUpdate) -> dict:
+        return {
+            "client_id":      c.client_id,
+            "round":          c.round,
+            "lat":            c.lat,
+            "lng":            c.lng,
+            "city":           c.city,
+            "country":        c.country,
+            "local_accuracy": c.local_accuracy,
+            "local_loss":     c.local_loss,
+            "num_samples":    c.num_samples,
+            "gradient_norm":  c.gradient_norm,
+            "bytes_sent":     c.bytes_sent,
+            "train_time_sec": c.train_time_sec,
+            "cpu_pct":        c.cpu_pct,
+            "ram_mb":         c.ram_mb,
+            "status":         c.status,
+        }

--- a/src/fedviz/map_metadata.py
+++ b/src/fedviz/map_metadata.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def merge_client_state(current: Optional[dict], update: dict) -> dict:
+    merged = dict(current or {})
+    for key, value in update.items():
+        if value is not None:
+            merged[key] = value
+    return merged
+
+
+def build_rounds_from_events(events: List[dict]) -> List[dict]:
+    by_round: Dict[int, Dict[str, Any]] = {}
+
+    for event in events:
+        round_num = event.get("round")
+        if round_num is None:
+            continue
+
+        round_state = by_round.setdefault(
+            round_num,
+            {
+                "round": round_num,
+                "globalAcc": None,
+                "globalLoss": None,
+                "duration": None,
+                "divergence": None,
+                "clients": {},
+            },
+        )
+
+        event_type = event.get("event_type")
+        if event_type == "round_end":
+            metrics = event.get("round_metrics", {})
+            if metrics.get("global_accuracy") is not None:
+                round_state["globalAcc"] = metrics.get("global_accuracy")
+            if metrics.get("global_loss") is not None:
+                round_state["globalLoss"] = metrics.get("global_loss")
+            if metrics.get("round_duration_sec") is not None:
+                round_state["duration"] = metrics.get("round_duration_sec")
+            if metrics.get("gradient_divergence") is not None:
+                round_state["divergence"] = metrics.get("gradient_divergence")
+
+        for client in event.get("clients", []):
+            client_id = client.get("client_id")
+            if client_id:
+                round_state["clients"][client_id] = merge_client_state(
+                    round_state["clients"].get(client_id),
+                    client,
+                )
+
+        if event_type == "comm_failure":
+            client_id = event.get("client_id")
+            if client_id:
+                round_state["clients"][client_id] = merge_client_state(
+                    round_state["clients"].get(client_id),
+                    {"client_id": client_id, "status": "failed"},
+                )
+
+    return [
+        {
+            "round": round_state["round"],
+            "globalAcc": round_state["globalAcc"],
+            "globalLoss": round_state["globalLoss"],
+            "duration": round_state["duration"],
+            "divergence": round_state["divergence"],
+            "clients": list(round_state["clients"].values()),
+        }
+        for _, round_state in sorted(by_round.items())
+    ]
+
+
+def build_map_metadata_from_events(events: List[dict]) -> dict:
+    init_event = next((event for event in events if event.get("event_type") == "init"), {})
+    finished_event = next(
+        (event for event in reversed(events) if event.get("event_type") == "finished"),
+        {},
+    )
+    return {
+        "schema_version": 1,
+        "run_id": init_event.get("run_id"),
+        "algorithm": init_event.get("algorithm"),
+        "config": init_event.get("config", {}),
+        "started_at": init_event.get("started_at"),
+        "finished_at": finished_event.get("timestamp"),
+        "rounds": build_rounds_from_events(events),
+    }

--- a/src/fedviz/map_server.py
+++ b/src/fedviz/map_server.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from socketserver import ThreadingMixIn
+from typing import Dict, List, Optional
+
+from .map_metadata import build_map_metadata_from_events
+
+logger = logging.getLogger("fedviz.map_server")
+
+
+class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+class MapServer:
+    def __init__(
+        self,
+        host: str = "0.0.0.0",
+        port: int = 7070,
+        runs_dir: str = "runs",
+        run_id: Optional[str] = None,
+        map_path: Optional[str] = None,
+        watch: bool = False,
+        poll_interval: float = 1.0,
+    ):
+        self.host = host
+        self.port = port
+        self.runs_dir = Path(runs_dir)
+        self.map_path = map_path
+        self.watch = watch
+        self.poll_interval = poll_interval
+
+        self._lock = threading.Lock()
+        self._subscribers: List[queue.Queue] = []
+        self._server: Optional[HTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._watch_thread: Optional[threading.Thread] = None
+        self._seen_offsets: Dict[Path, int] = {}
+        self._live_run_id: Optional[str] = run_id
+
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+
+    def start(self):
+        if self._server is not None:
+            return
+
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def do_OPTIONS(self):
+                self.send_response(200)
+                self._cors()
+                self.end_headers()
+
+            def do_GET(self):
+                path = self.path.rstrip("/")
+
+                if path == "" or path == "/map":
+                    self._serve_map()
+                elif path == "/stream":
+                    self._serve_sse()
+                elif path == "/health":
+                    self._serve_text("ok")
+                elif path == "/runs":
+                    self._serve_runs()
+                elif path.startswith("/runs/") and path.endswith("/metadata"):
+                    run_id = path[len("/runs/"):-len("/metadata")]
+                    self._serve_run_metadata(run_id)
+                elif path.startswith("/runs/") and path.endswith("/events"):
+                    run_id = path[len("/runs/"):-len("/events")]
+                    self._serve_run_events(run_id)
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def _serve_map(self):
+                candidates = []
+                if server.map_path:
+                    candidates.append(Path(server.map_path))
+                candidates += [
+                    Path("examples/fedviz_map.html"),
+                    Path("fedviz_map.html"),
+                    Path(__file__).parent.parent.parent / "examples" / "fedviz_map.html",
+                ]
+                for candidate in candidates:
+                    if candidate.exists():
+                        content = candidate.read_bytes()
+                        self.send_response(200)
+                        self.send_header("Content-Type", "text/html; charset=utf-8")
+                        self._cors()
+                        self.end_headers()
+                        self.wfile.write(content)
+                        return
+                self._serve_text("fedviz_map.html not found - place it in examples/", 404)
+
+            def _serve_sse(self):
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Cache-Control", "no-cache")
+                self.send_header("X-Accel-Buffering", "no")
+                self._cors()
+                self.end_headers()
+
+                self.wfile.write(b"data: {\"event_type\": \"connected\"}\n\n")
+                self.wfile.flush()
+
+                if server._live_run_id:
+                    mode = "live" if server.watch else "static"
+                    msg = json.dumps({
+                        "event_type": "init",
+                        "run_id": server._live_run_id,
+                        "mode": mode
+                    })
+                    self.wfile.write(f"data: {msg}\n\n".encode("utf-8"))
+                    self.wfile.flush()
+
+                    # In static mode, send all events immediately
+                    if not server.watch:
+                        jsonl_path = server.runs_dir / f"{server._live_run_id}.jsonl"
+                        if jsonl_path.exists():
+                            try:
+                                with jsonl_path.open("r", encoding="utf-8") as handle:
+                                    first = True
+                                    for line in handle:
+                                        line = line.strip()
+                                        if not line:
+                                            continue
+                                        # Skip the first "init" event from the file (file has its own)
+                                        if first:
+                                            try:
+                                                obj = json.loads(line)
+                                                if obj.get("event_type") == "init":
+                                                    first = False
+                                                    continue
+                                            except:
+                                                pass
+                                            first = False
+                                        self.wfile.write(f"data: {line}\n\n".encode("utf-8"))
+                                        self.wfile.flush()
+                            except Exception as exc:
+                                logger.warning("[fedviz] error reading events: %s", exc)
+                        # Send finish event to signal end of playback
+                        self.wfile.write(b"data: {\"event_type\": \"finished\"}\n\n")
+                        self.wfile.flush()
+                        return
+
+                q = server._subscribe()
+                try:
+                    while True:
+                        try:
+                            msg = q.get(timeout=25)
+                            self.wfile.write(msg.encode("utf-8"))
+                            self.wfile.flush()
+                        except queue.Empty:
+                            self.wfile.write(b"data: {\"event_type\": \"ping\"}\n\n")
+                            self.wfile.flush()
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+                finally:
+                    server._unsubscribe(q)
+
+            def _serve_runs(self):
+                runs = []
+                
+                # If a specific run_id was requested, only serve that run
+                if server._live_run_id:
+                    jsonl_path = server.runs_dir / f"{server._live_run_id}.jsonl"
+                    if not jsonl_path.exists():
+                        self._serve_text(f"run {server._live_run_id} not found", 404)
+                        return
+                    
+                    try:
+                        with jsonl_path.open("r", encoding="utf-8") as handle:
+                            first_line = handle.readline().strip()
+                            if first_line:
+                                header = json.loads(first_line)
+                                with jsonl_path.open("r", encoding="utf-8") as handle:
+                                    num_events = sum(1 for _ in handle)
+                                
+                                runs.append(
+                                    {
+                                        "run_id": header.get("run_id", jsonl_path.stem),
+                                        "algorithm": header.get("algorithm", "unknown"),
+                                        "started_at": header.get("started_at", ""),
+                                        "num_events": num_events,
+                                        "file": jsonl_path.name,
+                                        "metadata_file": f"{jsonl_path.stem}.map.json",
+                                        "has_metadata": (server.runs_dir / f"{jsonl_path.stem}.map.json").exists(),
+                                    }
+                                )
+                    except Exception as exc:
+                        logger.warning("[fedviz/map] could not read %s: %s", jsonl_path, exc)
+                else:
+                    # Serve all runs sorted by modification time
+                    for jsonl_path in sorted(
+                        server.runs_dir.glob("*.jsonl"),
+                        key=lambda p: p.stat().st_mtime,
+                        reverse=True,
+                    ):
+                        try:
+                            with jsonl_path.open("r", encoding="utf-8") as handle:
+                                first_line = handle.readline().strip()
+                                if not first_line:
+                                    continue
+                                header = json.loads(first_line)
+
+                            with jsonl_path.open("r", encoding="utf-8") as handle:
+                                num_events = sum(1 for _ in handle)
+
+                            runs.append(
+                                {
+                                    "run_id": header.get("run_id", jsonl_path.stem),
+                                    "algorithm": header.get("algorithm", "unknown"),
+                                    "started_at": header.get("started_at", ""),
+                                    "num_events": num_events,
+                                    "file": jsonl_path.name,
+                                    "metadata_file": f"{jsonl_path.stem}.map.json",
+                                    "has_metadata": (server.runs_dir / f"{jsonl_path.stem}.map.json").exists(),
+                                }
+                            )
+                        except Exception as exc:
+                            logger.warning("[fedviz/map] could not read %s: %s", jsonl_path, exc)
+
+                self._serve_json(runs)
+
+            def _serve_run_events(self, run_id: str):
+                jsonl_path = server.runs_dir / f"{run_id}.jsonl"
+                if not jsonl_path.exists():
+                    self._serve_text(f"run {run_id} not found", 404)
+                    return
+                self._serve_json(server.read_events(jsonl_path))
+
+            def _serve_run_metadata(self, run_id: str):
+                metadata_path = server.runs_dir / f"{run_id}.map.json"
+                if metadata_path.exists():
+                    try:
+                        with metadata_path.open("r", encoding="utf-8") as handle:
+                            self._serve_json(json.load(handle))
+                            return
+                    except Exception as exc:
+                        logger.warning("[fedviz/map] could not read %s: %s", metadata_path, exc)
+
+                jsonl_path = server.runs_dir / f"{run_id}.jsonl"
+                if not jsonl_path.exists():
+                    self._serve_text(f"run {run_id} not found", 404)
+                    return
+
+                self._serve_json(build_map_metadata_from_events(server.read_events(jsonl_path)))
+
+            def _serve_json(self, data):
+                body = json.dumps(data).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self._cors()
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _serve_text(self, text: str, code: int = 200):
+                body = text.encode("utf-8")
+                self.send_response(code)
+                self.send_header("Content-Type", "text/plain")
+                self._cors()
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _cors(self):
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+                self.send_header("Access-Control-Allow-Headers", "*")
+
+        self._server = ThreadedHTTPServer((self.host, self.port), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+        if self.watch:
+            self._prime_watch_offsets()
+            self._watch_thread = threading.Thread(target=self._watch_loop, daemon=True)
+            self._watch_thread.start()
+
+    def serve_forever(self):
+        self.start()
+        if self._thread is not None:
+            self._thread.join()
+
+    def stop(self):
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+
+    def publish(self, payload: dict):
+        if payload.get("run_id"):
+            self._live_run_id = payload["run_id"]
+        msg = f"data: {json.dumps(payload)}\n\n"
+        with self._lock:
+            dead = []
+            for subscriber in self._subscribers:
+                try:
+                    subscriber.put_nowait(msg)
+                except queue.Full:
+                    dead.append(subscriber)
+            for subscriber in dead:
+                self._subscribers.remove(subscriber)
+
+    def _subscribe(self) -> queue.Queue:
+        q: queue.Queue = queue.Queue(maxsize=200)
+        with self._lock:
+            self._subscribers.append(q)
+        return q
+
+    def _unsubscribe(self, q: queue.Queue):
+        with self._lock:
+            try:
+                self._subscribers.remove(q)
+            except ValueError:
+                pass
+
+    def _prime_watch_offsets(self):
+        if self._live_run_id:
+            # Only watch the specified run
+            jsonl_path = self.runs_dir / f"{self._live_run_id}.jsonl"
+            if jsonl_path.exists():
+                self._seen_offsets[jsonl_path] = jsonl_path.stat().st_size
+        else:
+            # Watch all runs
+            latest = self._find_latest_run_path()
+            if latest is not None:
+                self._live_run_id = latest.stem
+
+            for jsonl_path in self.runs_dir.glob("*.jsonl"):
+                self._seen_offsets[jsonl_path] = jsonl_path.stat().st_size
+
+    def _watch_loop(self):
+        while True:
+            try:
+                self._poll_run_files()
+            except Exception as exc:
+                logger.warning("[fedviz/map] watch loop error: %s", exc)
+            time.sleep(self.poll_interval)
+
+    def _poll_run_files(self):
+        for jsonl_path in sorted(self._seen_offsets.keys()):
+            size = jsonl_path.stat().st_size
+            offset = self._seen_offsets.get(jsonl_path, 0)
+
+            if size < offset:
+                offset = 0
+
+            if size == offset:
+                continue
+
+            with jsonl_path.open("r", encoding="utf-8") as handle:
+                handle.seek(offset)
+                for line in handle:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    self.publish(payload)
+                self._seen_offsets[jsonl_path] = handle.tell()
+
+            self._live_run_id = jsonl_path.stem
+
+    def _find_latest_run_path(self) -> Optional[Path]:
+        candidates = list(self.runs_dir.glob("*.jsonl"))
+        if not candidates:
+            return None
+        return max(candidates, key=lambda path: path.stat().st_mtime)
+
+    @staticmethod
+    def read_events(jsonl_path: Path) -> List[dict]:
+        events = []
+        with jsonl_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    pass
+        return events


### PR DESCRIPTION
# Description
This PR adds a geo-enabled HiveWatch map dashboard workflow for fedviz runs.

It introduces a map server/CLI flow that can serve live and historical run visualizations from persisted run artifacts, along with a bundled fedviz_map.html viewer. The map now supports:

- loading run history from runs/<run_id>.jsonl
- loading map-ready metadata from runs/<run_id>.map.json
- rendering the FL server location dynamically, with Argonne as a fallback
- This PR also updates the README and APPFL example docs to describe hivewatch map run usage and arguments.


### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes #XX
- Fixes #XX

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [ ] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ x ] Docs have been updated and reviewed if relevant.
