### PR TITLE
Fix live map round updates

### DIFF
--- a/src/hivewatch/emitters/sse_emitter.py
+++ b/src/hivewatch/emitters/sse_emitter.py
@@ -20,6 +20,7 @@ Directory structure:
 """
 from __future__ import annotations
 
+import errno
 import json
 import logging
 import threading
@@ -96,8 +97,10 @@ class SSEEmitter:
 
         print(f"[hivewatch/sse] run={run_id}")
         print(f"[hivewatch/sse] history → {jsonl_path}")
-        if self.serve_map:
+        if self._server is not None:
             print(f"[hivewatch/sse] dashboard → http://localhost:{self.port}")
+        elif self.serve_map:
+            print(f"[hivewatch/sse] port {self.port} already in use — using existing server at http://localhost:{self.port}")
         else:
             print(f"[hivewatch/sse] dashboard disabled; run `hivewatch map run --runs-dir {self.runs_dir}` to serve the map")
 
@@ -286,7 +289,20 @@ class SSEEmitter:
             map_path=self.map_path,
             watch=False,
         )
-        self._server.start()
+        try:
+            self._server.start()
+        except OSError as exc:
+            if exc.errno == errno.EADDRINUSE:
+                logger.warning(
+                    "[hivewatch/sse] port %d already in use — skipping embedded map server. "
+                    "Run data is still persisted; the existing server at http://localhost:%d "
+                    "will serve this run's history once it completes.",
+                    self.port,
+                    self.port,
+                )
+                self._server = None
+            else:
+                raise
 
     # ── Client dict ───────────────────────────────────────────────────────────
 

--- a/src/hivewatch/map/hivewatch_map.html
+++ b/src/hivewatch/map/hivewatch_map.html
@@ -700,6 +700,14 @@ function handleLiveEvent(msg) {
   const type = msg.event_type;
   dbg("connected", type);
   if (type === "ping" || type === "connected") return;
+  if (type !== "init") {
+    pb.events.push(msg);
+    pb.rounds = buildRounds(pb.events);
+    state.totalRounds = pb.rounds.length;
+    document.getElementById("play-btn").disabled = pb.rounds.length === 0 || state.mode === "live";
+    buildRoundTicks();
+    updateProgress();
+  }
 
   if (type === "server_metadata") {
     applyServerMetadata(msg.server);
@@ -1058,6 +1066,8 @@ function connect() {
         if (msg.mode === "live") {
           setMode("live");
           state.staticLoaded = false;
+          pb.events = [];
+          pb.rounds = [];
           addLog(`Live run started: ${msg.run_id}`, "round");
         } else {
           setMode("playback");

--- a/src/hivewatch/map/server.py
+++ b/src/hivewatch/map/server.py
@@ -44,6 +44,7 @@ class MapServer:
         self._watch_thread: Optional[threading.Thread] = None
         self._seen_offsets: Dict[Path, int] = {}
         self._live_run_id: Optional[str] = run_id
+        self._fixed_run_id = run_id is not None
 
         self.runs_dir.mkdir(parents=True, exist_ok=True)
 
@@ -111,12 +112,12 @@ class MapServer:
                 self.wfile.flush()
 
                 if server._live_run_id:
-                    mode = "live" if server.watch else "static"
+                    mode = "static" if server._fixed_run_id else "live"
                     msg = json.dumps({"event_type": "init", "run_id": server._live_run_id, "mode": mode})
                     self.wfile.write(f"data: {msg}\n\n".encode("utf-8"))
                     self.wfile.flush()
 
-                    if not server.watch:
+                    if server._fixed_run_id:
                         jsonl_path = server.runs_dir / f"{server._live_run_id}.jsonl"
                         if jsonl_path.exists():
                             try:
@@ -249,6 +250,8 @@ class MapServer:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(body)))
+                self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+                self.send_header("Pragma", "no-cache")
                 self._cors()
                 self.end_headers()
                 self.wfile.write(body)
@@ -257,6 +260,8 @@ class MapServer:
                 body = text.encode("utf-8")
                 self.send_response(code)
                 self.send_header("Content-Type", "text/plain")
+                self.send_header("Cache-Control", "no-store, no-cache, must-revalidate")
+                self.send_header("Pragma", "no-cache")
                 self._cors()
                 self.end_headers()
                 self.wfile.write(body)
@@ -312,3 +317,16 @@ class MapServer:
                 self._subscribers.remove(q)
             except ValueError:
                 pass
+
+    def read_events(self, jsonl_path: Path) -> List[dict]:
+        events = []
+        with jsonl_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    logger.warning("[hivewatch/map] could not parse %s: %s", jsonl_path, exc)
+        return events


### PR DESCRIPTION
# Description
Fixes live HiveWatch map behavior where new round details did not appear until the page was refreshed.

### Fixes
- Keep embedded SSEEmitter map sessions in live mode instead of treating them as static replay sessions.
- Update the browser-side round cache as live SSE events arrive.
- Add no-cache headers for map server JSON/text responses to avoid stale run metadata.

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [ ] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
